### PR TITLE
Update version to 2.6.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/ansicolors-feedstock/pr2/acffbaf

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/ansicolors-feedstock/pr2/acffbaf

--- a/recipe/0001_fix_test.patch
+++ b/recipe/0001_fix_test.patch
@@ -1,0 +1,12 @@
+diff --git a/papermill/tests/test_utils.py b/papermill/tests/test_utils.py
+index 4e24ce7..9edf861 100644
+--- a/papermill/tests/test_utils.py
++++ b/papermill/tests/test_utils.py
+@@ -55,6 +55,6 @@ def test_chdir():
+     with TemporaryDirectory() as temp_dir:
+         with chdir(temp_dir):
+             assert Path.cwd() != old_cwd
+-            assert Path.cwd() == Path(temp_dir)
++            assert Path.cwd().resolve() == Path(temp_dir).resolve()
+ 
+     assert Path.cwd() == old_cwd

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,6 +62,7 @@ test:
   requires:
     - boto3
     - moto >= 5.0.0,<5.1.0
+    - aiohttp
     - pip
     - pytest
     - ansicolors

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,54 +1,92 @@
 {% set name = "papermill" %}
-{% set version = "2.3.4" %}
+{% set version = "2.6.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: be12d2728989c0ae17b42fcb05b623500004e94b34f56bd153355ccebb84a59a
+  url: https://github.com/nteract/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
+  sha256: ddfd94093ce26e68b10c9546f596293e9bf7e13e2977ae7d4f0a8a3bd92ac95f
+  patches:
+    - 0001_fix_test.patch
 
 build:
   number: 0
   entry_points:
     - papermill = papermill.cli:papermill
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
-  noarch: python
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv --no-build-isolation
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
+    - setuptools
   run:
-    - ansiwrap
-    - black
+    - ansicolors
+    - aiohttp >=3.9.0 # [py312]
     - click
     - entrypoints
     - nbclient >=0.2.0
-    - nbformat >=5.1.2
-    - python >=3.6
+    - nbformat >=5.2.0
+    - python
     - pyyaml
     - requests
-    - tenacity
+    - tenacity >=5.0.2
     - tqdm >=4.32.2
 
+
+# Skip these tests because next packages are unavailable now in conda:     
+# - gcsfs>=0.2.0
+# - azure-datalake-store >= 0.0.30
+# - azure-identity>=1.3.1
+{% set ignore_tests = [
+  "--ignore=papermill/tests/test_abs.py",
+  "--ignore=papermill/tests/test_adl.py",
+  "--ignore=papermill/tests/test_gcs.py"
+] %}
+
+{% set ignore_tests_cases = [
+  # Jupyter required. but is incompatible with current packages
+  "test_output_formatting",
+  "TestBrokenNotebook2"
+] %}
+
 test:
+  source_files:
+    - pyproject.toml
+    - pytest.ini
+    - papermill
   imports:
     - papermill
+  requires:
+    - boto3
+    - moto >= 5.0.0,<5.1.0
+    - pip
+    - pytest
+    - ansicolors
+    - azure-storage-blob >= 12.1.0
+    - requests >= 2.21.0
+    - matplotlib
+    - ipywidgets
+    - ipykernel
+    - ipython>=5.0
+    - notebook
   commands:
     - papermill --help
     - pip check
-  requires:
-    - pip
+    - python -m pytest papermill/tests {{ ignore_tests | join(' ') }} -k "not ({{ ignore_tests_cases | join(' or ') }})"
 
 about:
-  home: http://github.com/nteract/papermill
+  home: https://github.com/nteract/papermill
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
   summary: Papermill parameterizes, executes, and analyzes Jupyter Notebooks.
-  doc_url: http://papermill.readthedocs.io/
+  description: |
+    Papermill is a tool for parameterizing and executing Jupyter Notebooks.
+    Papermill lets you parameterize notebooks and execute notebooks
+  doc_url: https://papermill.readthedocs.io/
   dev_url: https://github.com/nteract/papermill
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - setuptools
   run:
     - ansicolors
-    - aiohttp >=3.9.0 # [py312]
+    - aiohttp >=3.9.0 # [py==312]
     - click
     - entrypoints
     - nbclient >=0.2.0


### PR DESCRIPTION
papermill 2.6.0 

**Destination channel:** Defaults

### Links

- [PKG-8463]
- dev_url:        https://github.com/nteract/papermill/tree/2.6.0
- conda_forge:    https://github.com/conda-forge/papermill-feedstock
- pypi:           https://pypi.org/project/Papermill/2.6.0
- pypi inspector: https://inspector.pypi.io/project/Papermill/2.6.0

### Explanation of changes:

- new version number

[PKG-8463]: https://anaconda.atlassian.net/browse/PKG-8463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ